### PR TITLE
Use 31337 as hardhat network id. 

### DIFF
--- a/examples/hardhat.config.ts
+++ b/examples/hardhat.config.ts
@@ -12,7 +12,7 @@ import "@nomiclabs/hardhat-ethers"
 dotenv.config();
 
 const MAINNET_NETWORK_ID = 1
-const TEST_NETWORK_ID = 1337
+const TEST_NETWORK_ID = 31337
 
 const config: HardhatUserConfig = {
   solidity: "0.8.4",


### PR DESCRIPTION
Wallet is expecting 31337 as the localhost chain id for now, this would require a push to fix.